### PR TITLE
Add minimal installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,6 +3,15 @@ Installation
 
 This page describes the requirements and instructions for installing Spotlight.
 
+Minimal Installation
+~~~~~~~~~~~~~~~~~~~~
+
+*If you already have Anaconda3 and GSAS or GSAS-II installed, then you can follow the instructions in this subsection.*
+If you do not have GSAS or GSAS-II, then we provide an example of an advanced installation script below that also installs these packages in the virtual environment.
+You can create and load a virtual environment that contains Spotlight using the commands below.
+
+.. literalinclude:: ../tools/install_minimal.sh
+
 Dependencies
 ~~~~~~~~~~~~
 
@@ -32,8 +41,8 @@ This includes
 * `ImageMagick <https://imagemagick.org/index.php>`_ (7.0.8) for image processing,
 * and `gprof2dot <https://github.com/jrfonseca/gprof2dot>`_ (2017.9.19) for rendering DOT graphs for performance evaluation.
 
-Installation with Anaconda3
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Advanced Installation with Anaconda3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We include a script in the ``tools/`` directory to demonstrate how Spotlight can be installed inside an Anaconda3 environment; this script has been tested using Anaconda3 v4.7.10.
 Upon completion of the script below, the environment can be loaded with the command ``conda activate spotlight``.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -19,15 +19,8 @@ conda env remove --yes --name spotlight
 conda create --yes --name spotlight python=${PYTHON_VERSION}
 conda activate spotlight
 
-# install OpenMPI
-mkdir -p ${CONDA_PREFIX}/src && cd ${CONDA_PREFIX}/src
-wget https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.3.tar.gz
-tar -xvf openmpi-2.1.3.tar.gz
-cd openmpi-2.1.3
-CFLAGS=-O3 \
-CXXFLAGS=-O3 \
-./configure --prefix=${CONDA_PREFIX}
-make -j $(getconf _NPROCESSORS_ONLN) install
+# install MPI and Python bindings
+conda install --yes mpi4py==3.0.3
 
 # install GSAS which requires Python 2.7 for installation scripts
 conda install --yes python==2.7.16
@@ -47,7 +40,7 @@ chmod +x ${CONDA_PREFIX}/gsas/scripts/gsas_get_current_wtfrac_esd
 
 # install Python packages for Spotlight
 python -m pip install --upgrade pip
-python -m pip install --requirement ${TOOLS_DIR}/../requirements.txt
+python -m pip install --requirement ${TOOLS_DIR}/../requirements_rtd.txt
 
 # install GSAS-II
 # note proxy input is broken in GSAS-II bootstrap script

--- a/tools/install_minimal.sh
+++ b/tools/install_minimal.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+# create and load a virtual environment
+conda create --yes --name spotlight python=3.7.3
+conda activate spotlight
+
+# install MPI with Python bindings, Mystic, and Spotlight
+conda install --yes mpi4py==3.0.3
+python -m pip install klepto==0.1.7 https://github.com/uqfoundation/mystic/archive/5b73d70.tar.gz
+python -m pip install https://github.com/lanl/spotlight/archive/28128d9.tar.gz

--- a/tools/install_minimal.sh
+++ b/tools/install_minimal.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 # create and load a virtual environment
 conda create --yes --name spotlight python=3.7.3
 conda activate spotlight
@@ -7,4 +9,4 @@ conda activate spotlight
 # install MPI with Python bindings, Mystic, and Spotlight
 conda install --yes mpi4py==3.0.3
 python -m pip install klepto==0.1.7 https://github.com/uqfoundation/mystic/archive/5b73d70.tar.gz
-python -m pip install https://github.com/lanl/spotlight/archive/28128d9.tar.gz
+python -m pip install https://github.com/lanl/spotlight/archive/master.tar.gz


### PR DESCRIPTION
Includes a minimal installation in documentation for those with Anaconda3 and GSAS/GSAS-II already.

Also, install MPI and Python bindings from Anaconda3.