### PR TITLE
Pass arguments from configuration file to creating solver

### DIFF
--- a/spotlight/filesystem.py
+++ b/spotlight/filesystem.py
@@ -55,7 +55,10 @@ def cp(paths, dest=None):
     for path in paths_list:
         final_path = dest + "/" + os.path.basename(path) if dest \
                          else os.path.basename(path)
-        shutil.copyfile(path, final_path)
+        try:
+            shutil.copyfile(path, final_path)
+        except shutil.SameFileError:
+            print("File {} already exists!".format(path))
 
     # typecast paths to str
     paths_out = [os.path.basename(path) for path in paths_list]

--- a/spotlight/io/configuration_file.py
+++ b/spotlight/io/configuration_file.py
@@ -187,7 +187,7 @@ class ConfigurationFile(object):
 
         return cost
 
-    def get_solver(self, arch=None, iteration=None):
+    def get_solver(self, **kwargs):
         """ Returns instance of requested solver.
 
         Returns
@@ -202,21 +202,20 @@ class ConfigurationFile(object):
 
         # store all options from [solver]
         section = "solver"
-        options = {}
         for option in cp.options(section):
             val = cp.get(section, option)
             if val.isdigit():
-                options[option] = int(val)
+                kwargs[option] = int(val)
             else:
                 try:
                     val = float(val)
-                    options[option] = val
+                    kwargs[option] = val
                 except ValueError:
-                    options[option] = val
+                    kwargs[option] = val
 
         # initialize solver
         local_solver = solver.Solver(self.lower_bounds, self.upper_bounds,
-                                     arch=arch, iteration=iteration, **options)
+                                     **kwargs)
 
         return local_solver
 

--- a/spotlight/solver.py
+++ b/spotlight/solver.py
@@ -99,7 +99,6 @@ class Solver(object):
             elif self.sampling_method == "tolerance":
                 raise ValueError("Must give iteration with tolerance sampling.")
         p0 = sampling.sampling_methods[self.sampling_method](*args)
-        print("INIITAL POINTS ARE", p0)
         self.local_solver.SetInitialPoints(p0)
         self.local_solver.SetStrictRanges(self.lower_bounds, self.upper_bounds)
 

--- a/spotlight/solver.py
+++ b/spotlight/solver.py
@@ -44,7 +44,8 @@ class Solver(object):
         Number of solvers already run. Only required for some sampling methods.
     """
 
-    def __init__(self, lower_bounds, upper_bounds, arch=None, iteration=None, **kwargs):
+    def __init__(self, lower_bounds, upper_bounds, arch=None,
+                 iteration=None, sampling_data=None, **kwargs):
 
         # set required options
         self.lower_bounds = lower_bounds
@@ -86,17 +87,19 @@ class Solver(object):
 
         # set bounds
         args = [self.lower_bounds, self.upper_bounds]
-        if (self.sampling_method == "tolerance" and
-                iteration > self.sampling_iteration_switch):
-            sampling_data = solution_file.SolutionFile.read_data([arch.path])[1]
-            if len(sampling_data):
-                sampling_data = tuple(map(tuple, numpy.vstack(sampling_data)))
-                args += [sampling_data]
-        elif self.sampling_method == "tolerance" and iteration != None:
-            args += [[]]
-        elif self.sampling_method == "tolerance":
-            raise ValueError("Must give iteration with tolerance sampling.")
+        if self.sampling_method == "tolerance":
+            if iteration > self.sampling_iteration_switch:
+                if sampling_data is None:
+                    sampling_data = solution_file.SolutionFile.read_data([arch.path])[1]
+                if len(sampling_data):
+                    sampling_data = tuple(map(tuple, numpy.vstack(sampling_data)))
+                    args += [sampling_data]
+            elif self.sampling_method == "tolerance" and iteration != None:
+                args += [[]]
+            elif self.sampling_method == "tolerance":
+                raise ValueError("Must give iteration with tolerance sampling.")
         p0 = sampling.sampling_methods[self.sampling_method](*args)
+        print("INIITAL POINTS ARE", p0)
         self.local_solver.SetInitialPoints(p0)
         self.local_solver.SetStrictRanges(self.lower_bounds, self.upper_bounds)
 


### PR DESCRIPTION
This PR passes keyword arguments from ``ConfigurationFile.get_solver`` to ``solver.Solver`` when its initialized. So the tolerance sampling method can be used without a solution file (only in memory).

This PR also skips copying a file if it already exists.