### PR TITLE
Do not require Plan.initialize on initialization

### DIFF
--- a/spotlight/io/configuration_file.py
+++ b/spotlight/io/configuration_file.py
@@ -187,7 +187,7 @@ class ConfigurationFile(object):
         if tmp_dir is not None:
             filesystem.mkdir(tmp_dir, change=change)
 
-    def get_refinement_plan(self, reimport=True):
+    def get_refinement_plan(self, initialize=True, reimport=True):
         """ Returns instance of requested refinement plan.
 
         Returns
@@ -208,7 +208,8 @@ class ConfigurationFile(object):
 
         # initialize refinement plan
         ndim = len(self.names)
-        cost = self.refinement_plan.Plan(self.idxs, self.bounds, ndim=ndim, **self.items)
+        cost = self.refinement_plan.Plan(self.idxs, self.bounds, ndim=ndim,
+                                         initialize=initialize, **self.items)
 
         return cost
 

--- a/spotlight/plan.py
+++ b/spotlight/plan.py
@@ -37,7 +37,7 @@ class BasePlan(models.AbstractFunction):
         A list of ``Phase`` instances.
     """
 
-    def __init__(self, idxs, bounds, ndim, **kwargs):
+    def __init__(self, idxs, bounds, ndim, initialize=True, **kwargs):
         super(BasePlan, self).__init__(ndim=ndim)
 
         # store map to parameters
@@ -50,7 +50,8 @@ class BasePlan(models.AbstractFunction):
             setattr(self, key, val)
 
         # setup initial porition of refinement plan
-        self.initialize()
+        if initialize:
+            self.initialize()
 
     def initialize(self):
         """ Function called once before optimization.


### PR DESCRIPTION
Do not require that ``Plan.initialize`` is run automatically on ``Plan.__init__``. Uses argument ``initialize=True``.