### PR TITLE
Set version to None for Windows if not version not found.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def generate_version_module():
         info = __version__.Version()
         info.version = "static"
         info.release = "False"
-        info.last_relase = 0
+        info.last_release = 0
 
     # contents of version module
     contents = """
@@ -96,7 +96,7 @@ version = generate_version_module()
 
 # meta-data about the package
 project_name = "spotlight"
-project_version = version.last_release if version.release == "True" else version.last_release + ".dev0"
+project_version = version.last_release if version.release == "True" else None
 project_url = "https://github.lanl.gov/lanl/spotlight"
 project_description = "A package for parallel optimization and Rietveld refinement."
 project_keywords = ["crystallography"]


### PR DESCRIPTION
If ``Version`` not built then set the ``project_version`` to ``None``. Otherwise Windows builds cannot install with Anaconda trying to check version for ``None.dev0``.