### PR TITLE
Docker setup + readme for GSAS2 PbSO4 example

### DIFF
--- a/examples/lead_sulphate/Dockerfile
+++ b/examples/lead_sulphate/Dockerfile
@@ -36,6 +36,12 @@ RUN mkdir -p ${GSAS2_PATH} \
     && python ./bootstrap.py noproxy
 
 # Get Spotlight repo for examples (change this to just git clone -b <tag> when we want to use a tagged version instead of by commit)
+
+# TODO: After spolight version 0.10.3 is released, use following instead
+#     ARG ${SPOTLIGHT_VERSION}="v0.10.3"
+# and
+#     RUN git clone -b ${SPOTLIGHT_VERSION} https://github.com/lanl/spotlight.git
+
 RUN git clone https://github.com/lanl/spotlight.git \
     && cd spotlight \
     && git checkout ${SPOTLIGHT_VERSION}

--- a/examples/lead_sulphate/Dockerfile
+++ b/examples/lead_sulphate/Dockerfile
@@ -1,0 +1,46 @@
+ARG CONDA_VERSION=23.3.1-0
+FROM continuumio/miniconda3:${CONDA_VERSION} as gsas2-setup
+
+ARG CONDA_ENV=spotlight-gsas2
+ENV PATH /opt/conda/envs/$CONDA_ENV/bin:$PATH
+
+WORKDIR /app
+
+# Install wxpython GSAS2 dependency
+RUN apt update \
+    && apt install -y \
+        libxxf86vm-dev \
+        libwxgtk3.0-gtk3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY environment.yaml .
+RUN conda env create --name ${CONDA_ENV} -f environment.yaml
+
+RUN echo "conda activate $CONDA_ENV" >> ~/.bashrc
+
+#-------------------------------------------------------------------------------#
+FROM gsas2-setup as gsas2-env
+
+ENV NO_MPIRUN="true"
+
+# Version of spotlight to use (from 2023-06-08)
+ARG SPOTLIGHT_VERSION="ecf0ae092aef0d632f05e372c2619ebc70dfc630"
+ARG GSAS2_VERSION="5609"
+ARG GSAS2_PATH="/gsas2"
+ENV PYTHONPATH="${PYTHONPATH}:${GSAS2_PATH}:${GSAS2_PATH}/bindist"
+
+# Install GSAS-II
+RUN mkdir -p ${GSAS2_PATH} \
+    && cd ${GSAS2_PATH} \
+    && svn export -r ${GSAS2_VERSION} https://subversion.xray.aps.anl.gov/pyGSAS/install/bootstrap.py \
+    && python ./bootstrap.py noproxy
+
+# Get Spotlight repo for examples (change this to just git clone -b <tag> when we want to use a tagged version instead of by commit)
+RUN git clone https://github.com/lanl/spotlight.git \
+    && cd spotlight \
+    && git checkout ${SPOTLIGHT_VERSION}
+
+# Copy in PbSO4 example
+COPY . .
+
+CMD ["sh", "./run_spotlight.sh"]

--- a/examples/lead_sulphate/README.md
+++ b/examples/lead_sulphate/README.md
@@ -1,0 +1,48 @@
+# Spotlight + GSAS2 example: PbSO4
+
+This example shows Spotlight + [GSAS2][gsas2] applied to PbSO4
+
+# Example using conda
+
+First, you will need [conda][conda] installed on your machine.
+
+Use either the local `environment.yaml` or the `../../environment_gsas2.yaml` files to create a [conda][conda] environment:
+```
+conda env create -n spotlight-gsas2-pbso4 -f environment.yml
+```
+
+Activate the environment:
+```
+conda activate spotlight-gsas2-pbso4
+```
+
+Install GSAS2 using revsion 5609 (tested version):
+```
+svn export -r 5609 https://subversion.xray.aps.anl.gov/pyGSAS/install/bootstrap.py
+python ./bootstrap.py noproxy
+```
+_DISCLAIMER: This will install all the GSAS2 files in the current directory_
+
+Run the example:
+```
+bash ./run_spotlight.sh
+```
+
+
+# Example using docker (on linux)
+
+First, you will need [Docker][docker] installed on your machine.
+
+Build the container image:
+```
+docker build -t spotlight-gsas2-pbso4 .
+```
+
+Then, you can run the example while mounting the output directory to your host machine:
+```
+docker run -v ./output:/app/tmp_spotlight_123 spotlight-gsas2-pbso4
+```
+
+_DISCLAIMER: you may need to delete the `output/` directory using `sudo`_
+_i.e. `sudo rm -rf output/`_
+_This is due to `root` writing these files inside the container._

--- a/examples/lead_sulphate/README.md
+++ b/examples/lead_sulphate/README.md
@@ -28,7 +28,6 @@ Run the example:
 bash ./run_spotlight.sh
 ```
 
-
 # Example using docker (on linux)
 
 First, you will need [Docker][docker] installed on your machine.
@@ -46,3 +45,7 @@ docker run -v ./output:/app/tmp_spotlight_123 spotlight-gsas2-pbso4
 _DISCLAIMER: you may need to delete the `output/` directory using `sudo`_
 _i.e. `sudo rm -rf output/`_
 _This is due to `root` writing these files inside the container._
+
+[gsas2]: https://subversion.xray.aps.anl.gov/trac/pyGSAS
+[conda]: https://docs.conda.io/en/latest/
+[docker]: https://docs.docker.com/

--- a/examples/lead_sulphate/environment.yaml
+++ b/examples/lead_sulphate/environment.yaml
@@ -1,0 +1,33 @@
+name: spotlight-gsas2
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=3.10
+
+  # Spotlight
+  - klepto=0.2.2
+  - matplotlib=3.5.2
+  - numpy=1.23.0
+  - pip=22.1.2
+  - openmpi=4.1.4
+  - mpi4py=3.1.3
+
+  # GSAS-2 extras (some overlap with spotlight)
+  - pyopengl
+  - wxpython=4.2
+  - scipy
+  - pillow
+  - h5py
+  - imageio
+  - subversion
+  - requests
+  - xmltodict
+
+  - pip:
+    - git+https://github.com/lanl/spotlight.git@v0.10.2
+    - mystic==0.3.9
+    - pyina==0.2.6
+    - pathos==0.2.9

--- a/examples/lead_sulphate/run_spotlight.sh
+++ b/examples/lead_sulphate/run_spotlight.sh
@@ -6,12 +6,15 @@
 
 set -e
 
+# Can be used to override using MPI ("" for true, false otherwise)
+USE_MPI=""
+
 # random seed
 SEED=${1}
 SEED=${SEED:=123}
 
 # if MPI is installed then use it
-if [ -x "$(command -v mpirun)" ]; then
+if [ -x "$(command -v mpirun)" ] && [ $USE_MPIRUN ]; then
     export OMP_NUM_THREADS=1
     EXE="mpirun --oversubscribe -n 4 python -m cProfile -o analytical.pstat `which spotlight_minimize`"
 else


### PR DESCRIPTION
Work includes:
  - Adds Dockerfile to PbSO4 GSAS2 example for building container image for the example

  - Adds an `environment.yaml` to PbSO4 GSAS2 example; did not use the `tools/environment_gsas2.yaml` since need a "directory-local" environment file for the container image to be built in this directory for just this example; Otherwise, would have to put the Dockerfile at same directory level or above where `tools` directory is to pull in the `environment_gsas2.yaml`. Could copy the `tools/environment_gsas2.yaml` here as well but had this one working already (I'm happy to change if needed)

  - Adds a README to the PbSO4 example for using conda + docker

  - Adds running `mpirun` as optional in `run_spotlight.sh`; disables this for Dockerfile for now (in future, can work to add running `mpirun` in the container as well)


To test (for docker):
  - Using the new README in the example, build the container image use docker:
      ```
    docker build -t spotlight-gsas2-pbso4 .
    ```
  - Run a container off this container image to run the example:
    ```
    docker run -v ./output:/app/tmp_spotlight_123 spotlight-gsas2-pbso4
    ```

  - Check / validate the stdout and the `output/` directory for correct results

  - Cleanup: `sudo rm -rf output/`

Not covered in this PR but can be addressed in future:
  - Add mpi ability in the Dockerfile
  - Possibly move `environment_gsas2.yaml` to just the example directory to remove duplication? Or move the Dockerfile up (yet, currently specific to this example)
  - Add a general Dockerfile to run spotlight inside (could modify this example-specific one to accomplish this)